### PR TITLE
Prior fix

### DIFF
--- a/tspyro/models.py
+++ b/tspyro/models.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pyro
 import pyro.distributions as dist
 import torch
@@ -64,7 +63,8 @@ class BaseModel(PyroModule):
         base_priors.add(ts.num_samples, True)
 
         for total_fixed in span_data.total_fixed_at_0_counts:
-            # For missing data: trees vary in total fixed node count => have different priors
+            # For missing data: trees vary in total fixed node count => have
+            # different priors
             if total_fixed > 0:
                 base_priors.add(total_fixed, True)
 


### PR DESCRIPTION
Modify the prior in `tspyro` so that we use the location and scale parameters of the lognormal distribution for each node, fit to the expectation and variance of the age of each node under the conditional coalescent. Previously, we estimated these from the discretized times from the tsdate-produced prior object.

Also formatted `models.py` with `black`